### PR TITLE
Handle null NetworkSettings.Ports.[].

### DIFF
--- a/src/Normalizer/NetworkSettingsNormalizer.php
+++ b/src/Normalizer/NetworkSettingsNormalizer.php
@@ -57,8 +57,10 @@ class NetworkSettingsNormalizer implements DenormalizerInterface, NormalizerInte
             $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'Ports'} as $key => $value) {
                 $values_1 = [];
-                foreach ($value as $value_1) {
-                    $values_1[] = $this->denormalizer->denormalize($value_1, 'Docker\\API\\Model\\PortBinding', 'json', $context);
+                if ($value !== null) {
+                    foreach ($value as $value_1) {
+                        $values_1[] = $this->denormalizer->denormalize($value_1, 'Docker\\API\\Model\\PortBinding', 'json', $context);
+                    }
                 }
                 $values[$key] = $values_1;
             }


### PR DESCRIPTION
Hi, this PR solves a case when docker returns null section Ports.